### PR TITLE
Add PicocliRunner.execute API

### DIFF
--- a/picocli/src/test/java/io/micronaut/configuration/picocli/PicocliRunnerTest.java
+++ b/picocli/src/test/java/io/micronaut/configuration/picocli/PicocliRunnerTest.java
@@ -1,0 +1,160 @@
+package io.micronaut.configuration.picocli;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.Before;
+import org.junit.Test;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.matchers.JUnitMatchers.containsString;
+
+public class PicocliRunnerTest {
+
+    private static final int EXIT_CODE_INVALID_INPUT = 222;
+    private static final int EXIT_CODE_EXECUTION_ERROR = 123;
+
+    @Before
+    public void before() {
+        MyRunnableCmd.serviceResult = null;
+        MyRunnableCmd.verbose = false;
+
+        MyCallableCmd.x = 0;
+        MyCallableCmd.y = 0;
+    }
+
+    @Singleton
+    static class MyService {
+        public String service() {
+            return "good service";
+        }
+    }
+
+    @Command(name = "myRunnable", mixinStandardHelpOptions = true)
+    static class MyRunnableCmd implements Runnable {
+
+        @Inject
+        MyService myService;
+
+        /** Command line option value for -v captured in static field for testing */
+        @Option(names = {"-v", "--verbose"}, description = "...")
+        static boolean verbose;
+
+        /** Execution result captured in static field for testing */
+        static String serviceResult;
+
+        public void run() {
+            if (verbose) {
+                System.out.println("myService: " + myService);
+            }
+            serviceResult = myService.service();
+        }
+    }
+
+    @Command(name = "myCallable", exitCodeOnInvalidInput = EXIT_CODE_INVALID_INPUT)
+    static class MyCallableCmd implements Callable<Integer> {
+
+        /** Command line option value for -x captured in static field for testing */
+        @Option(names = "-x")
+        static int x;
+
+        /** Command line option value for -y captured in static field for testing */
+        @Option(names = "-y")
+        static int y;
+
+        /** Returns the result of multiplying x * y. */
+        public Integer call() {
+            return x * y;
+        }
+    }
+
+    @Command(name = "badCallable", exitCodeOnExecutionException = EXIT_CODE_EXECUTION_ERROR)
+    static class BadCallableCmd implements Callable<Integer> {
+
+        /** Always throws an exception. */
+        public Integer call() {
+            throw new IllegalStateException("internal error");
+        }
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        // preconditions
+        assertFalse(MyRunnableCmd.verbose);
+        assertNull(MyRunnableCmd.serviceResult);
+
+        // exercise SUT
+        PicocliRunner.run(MyRunnableCmd.class, "-v");
+
+        // verify
+        assertTrue(MyRunnableCmd.verbose);
+        assertEquals(MyRunnableCmd.serviceResult, new MyService().service());
+    }
+
+    @Test
+    public void testCall() throws Exception {
+        // preconditions
+        assertEquals(0, MyCallableCmd.x);
+        assertEquals(0, MyCallableCmd.y);
+
+        // exercise SUT
+        int result = PicocliRunner.call(MyCallableCmd.class, "-x=11", "-y", "3");
+
+        // verify
+        assertEquals(33, result);
+        assertEquals(11, MyCallableCmd.x);
+        assertEquals(3, MyCallableCmd.y);
+    }
+
+    @Test
+    public void testExecuteNormal() {
+        int exitCode = PicocliRunner.execute(MyRunnableCmd.class, "-v");
+        assertEquals(0, exitCode);
+    }
+
+    @Test
+    public void testExecuteNonZeroExitCode() {
+        int exitCode = PicocliRunner.execute(MyCallableCmd.class, "-x=11", "-y", "3");
+        assertEquals(33, exitCode);
+    }
+
+    @Test
+    public void testExecuteInvalidUserInput() {
+        PrintStream oldErr = System.err;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(baos));
+
+            int exitCode = PicocliRunner.execute(MyCallableCmd.class, "-x=NotANumber");
+            assertEquals(EXIT_CODE_INVALID_INPUT, exitCode);
+
+            assertThat(baos.toString(), containsString("Invalid value for option '-x': 'NotANumber' is not an int"));
+        } finally {
+            System.setErr(oldErr);
+        }
+    }
+
+    @Test
+    public void testExecuteErrorDuringExecution() {
+        PrintStream oldErr = System.err;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(baos));
+
+            int exitCode = PicocliRunner.execute(BadCallableCmd.class);
+            assertEquals(EXIT_CODE_EXECUTION_ERROR, exitCode);
+
+            assertThat(baos.toString(), containsString("java.lang.IllegalStateException: internal error"));
+        } finally {
+            System.setErr(oldErr);
+        }
+    }
+}
+

--- a/src/main/docs/guide/quickstart.adoc
+++ b/src/main/docs/guide/quickstart.adoc
@@ -57,8 +57,9 @@ public class GitStarCommand implements Runnable {
                 "  Default: ${DEFAULT-VALUE}"}, split = ",", paramLabel = "<owner/repo>") // <4>
     List<String> githubSlugs = Arrays.asList("micronaut-projects/micronaut-core", "remkop/picocli");
 
-    public static void main(String[] args) throws Exception {
-        PicocliRunner.run(GitStarCommand.class, args);
+    public static void main(String[] args) {
+        int exitCode = PicocliRunner.execute(GitStarCommand.class, args);
+        System.exit(exitCode);
     }
 
     public void run() { // <5>
@@ -102,8 +103,8 @@ The easiest way to do this is to declare the subcommands on the top-level comman
 @Command(name = "topcmd", subcommands = {SubCmd1.class, SubCmd2.class}) // <1>
 class TopCommand implements Callable<Object> { // <2>
 
-    public static void main(String[] args) throws Exception {
-        PicocliRunner.call(TopCommand.class, args); // <3>
+    public static void main(String[] args) {
+        PicocliRunner.execute(TopCommand.class, args); // <3>
     }
     //...
 }
@@ -111,3 +112,49 @@ class TopCommand implements Callable<Object> { // <2>
 <1> The top-level command has two subcommands, `SubCmd1` and `SubCmd2`.
 <2> Let all commands in the hierarchy implement `Runnable` or `Callable`.
 <3> Start the application with `PicocliRunner`. This creates an `ApplicationContext` that instantiates the commands and performs the dependency injection.
+
+=== Customizing Picocli
+
+Occasionally you may want to set parser options or otherwise customize picocli behavior.
+This can easily be done via the setter methods on the picocli `CommandLine` object, but the `PicocliRunner` does not expose that object.
+
+In such cases, you may want to invoke picocli directly instead of using the `PicocliRunner`.
+The code below demonstrates how to do this:
+
+.Example of customizing the picocli parser before invoking a command
+[source,java]
+----
+import io.micronaut.configuration.picocli.MicronautFactory;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import picocli.CommandLine;
+import picocli.CommandLine.*;
+import java.util.concurrent.Callable;
+
+@Command(name = "configuration-example")
+class ConfigDemo implements Callable<Object> {
+
+    private static int execute(Class<?> clazz, String[] args) {
+        try (ApplicationContext context = ApplicationContext.build(
+                clazz, Environment.CLI).start()) { // <1>
+
+            return new CommandLine(clazz, new MicronautFactory(context)). // <2>
+                 setCaseInsensitiveEnumValuesAllowed(true). // <3>
+                 setUsageHelpAutoWidth(true). // <4>
+                 execute(args); // <5>
+        }
+    }
+
+    public static void main(String[] args) {
+        int exitCode = execute(ConfigDemo.class, args);
+        System.exit(exitCode); // <6>
+    }
+    // ...
+}
+----
+<1> Instantiate a new `ApplicationContext` for the `CLI` environment, in a try-with-resources statements, so that the context is automatically closed before the method returns.
+<2> Pass a `MicronautFactory` with the application context to the picocli `CommandLine` constructor. This enables dependencies to be injected into the command and subcommands.
+<3> An example of configuring the picocli command line parser.
+<4> An example of configuring the picocli usage help message.
+<5> Execute the command and return the result (this closes the application context).
+<6> Optionally call `System.exit` with the returned exit code.


### PR DESCRIPTION
This PR updates `PicocliRunner` for the new API introduced in picocli 4.0.

* add `execute` method to `PicocliRunner`
* add PicocliRunner tests
* update documentation to use the `execute` method instead of `run` or `call`
* add documentation section demonstrating how to customize picocli parser options (without PicocliRunner)