### PR TITLE
Bump picocli to 4.0.3

### DIFF
--- a/picocli/build.gradle
+++ b/picocli/build.gradle
@@ -21,6 +21,6 @@ dependencies {
     compile "io.micronaut:micronaut-inject:$micronautVersion"
     compile "io.micronaut:micronaut-runtime:$micronautVersion"
     compileOnly 'io.micronaut:micronaut-graal'
-    compile "info.picocli:picocli:4.0.2"    
+    compile "info.picocli:picocli:4.0.3"    
     testCompile 'junit:junit:4.7'
 }


### PR DESCRIPTION
See https://github.com/remkop/picocli/releases/tag/v4.0.3

Release 4.0.3 has a bugfix for a problem where Argument groups disappeared in GraalVM native-image (the generated reflect-config.json was missing the @ArgGroup-annotated fields).