### PR TITLE
build: add picocli-codegen as a managed dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,3 +3,4 @@ managed-picocli = "4.6.3"
 
 [libraries]
 managed-picocli = { module = "info.picocli:picocli", version.ref = "managed-picocli" }
+managed-picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "managed-picocli" }


### PR DESCRIPTION
When adding the new 4.2.0 BOM to micronaut-core here https://github.com/micronaut-projects/micronaut-core/pull/7413, it was spotted that we lost a versioned dependency on picocli-codegen when we generate the core BOM.

This change adds it back in.