### PR TITLE
Document that picocli-codegen annotation processor requires Kapt for Kotlin projects

### DIFF
--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -6,7 +6,7 @@ The `picocli-codegen` module includes an annotation processor that can build a m
 
 dependency:picocli-codegen[scope="annotationProcessor", groupId="info.picocli"]
 
-NOTE: The `picocli-codegen` annotation processor is incompatible with the _Kotlin KSP_ compiler plugin. Using it in a Kotlin project requires the _Kotlin Kapt_ compiler plugin instead. For more information see link:https://github.com/remkop/picocli/issues/1564[KSP support for Kotlin?]
+NOTE: The https://github.com/remkop/picocli/issues/1564[`picocli-codegen` annotation processor is incompatible with the _Kotlin KSP_ compiler plugin]. Using it in a Kotlin project requires the _Kotlin Kapt_ compiler plugin instead. 
 
 === Configuring picocli
 

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -6,6 +6,8 @@ The `picocli-codegen` module includes an annotation processor that can build a m
 
 dependency:picocli-codegen[scope="annotationProcessor", groupId="info.picocli"]
 
+NOTE: The `picocli-codegen` annotation processor is incompatible with the _Kotlin KSP_ compiler plugin. Using it in a Kotlin project requires the _Kotlin Kapt_ compiler plugin instead.
+
 === Configuring picocli
 
 Picocli does not require configuration. See other sections of the manual for configuring the services and resources to inject.

--- a/src/main/docs/guide/setup.adoc
+++ b/src/main/docs/guide/setup.adoc
@@ -6,7 +6,7 @@ The `picocli-codegen` module includes an annotation processor that can build a m
 
 dependency:picocli-codegen[scope="annotationProcessor", groupId="info.picocli"]
 
-NOTE: The `picocli-codegen` annotation processor is incompatible with the _Kotlin KSP_ compiler plugin. Using it in a Kotlin project requires the _Kotlin Kapt_ compiler plugin instead.
+NOTE: The `picocli-codegen` annotation processor is incompatible with the _Kotlin KSP_ compiler plugin. Using it in a Kotlin project requires the _Kotlin Kapt_ compiler plugin instead. For more information see link:https://github.com/remkop/picocli/issues/1564[KSP support for Kotlin?]
 
 === Configuring picocli
 


### PR DESCRIPTION
closes #351